### PR TITLE
Centos 6 fixes

### DIFF
--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -35,7 +35,7 @@ parser.add_argument(
     '-M', '--max-message-length',
     type=int,
     default=DEFAULT_MAX_MESSAGE_LENGTH,
-    help='The maximum characters of a string that should be sent to Sentry (defaults to {})'.format(DEFAULT_MAX_MESSAGE_LENGTH),
+    help='The maximum characters of a string that should be sent to Sentry (defaults to {0})'.format(DEFAULT_MAX_MESSAGE_LENGTH),
 )
 parser.add_argument(
     '--version',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     ],
     url='http://github.com/yipit/cron-sentry',
     packages=find_packages(),
-    install_requires=['raven'],
+    install_requires=['raven', 'argparse'],
     data_files=[],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
+from sys import version_info
 from cron_sentry.version import VERSION
+
+requirements = ['raven']
+if version_info < (2, 7, 0):
+    requirements.append('argparse')
 
 setup(
     name='cron-sentry',
@@ -18,7 +23,7 @@ setup(
     ],
     url='http://github.com/yipit/cron-sentry',
     packages=find_packages(),
-    install_requires=['raven', 'argparse'],
+    install_requires=requirements,
     data_files=[],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Add missing argparse requirement for installation. 

Also added index identifier to string format operation. This makes cron-sentry compatible with python 2.6 which EL6 still runs.
https://docs.python.org/2.7/library/string.html#format-string-syntax