### PR TITLE
Bug fix for one char truncated strings

### DIFF
--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -139,7 +139,7 @@ class CommandReporter(object):
 
         message = "Command \"%s\" failed" % (self.command,)
 
-        client = Client(dsn=self.dsn)
+        client = Client(dsn=self.dsn, string_max_length=None)
 
         client.captureMessage(
             message,

--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -139,7 +139,7 @@ class CommandReporter(object):
 
         message = "Command \"%s\" failed" % (self.command,)
 
-        client = Client(dsn=self.dsn, string_max_length=-1)
+        client = Client(dsn=self.dsn)
 
         client.captureMessage(
             message,


### PR DESCRIPTION
Argument string_max_length=-1 make Raven truncate one char at the end of all strings in the command and sys.argv lists. I think it should just be removed.