### PR TITLE
Replace max_message_lenght with string_max_lenght and pass to Raven

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ optional arguments:
   --dsn SENTRY_DSN      Sentry server address
   -M STRING_MAX_LENGTH, --string-max-length STRING_MAX_LENGTH
                         The maximum characters of a string that should be sent
-                        to Sentry (defaults to 4094)
+                        to Sentry (defaults to 4096)
   -q, --quiet           suppress all command output
   --version             show program's version number and exit
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage
 
 ```
 $ cron-sentry --help
-usage: cron-sentry [-h] [--dsn SENTRY_DSN] [-M MAX_MESSAGE_LENGTH] [--quiet] [--version] cmd [arg ...]
+usage: cron-sentry [-h] [--dsn SENTRY_DSN] [-M STRING_MAX_LENGTH] [--quiet] [--version] cmd [arg ...]
 
 Wraps commands and reports those that fail to Sentry.
 
@@ -23,7 +23,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --dsn SENTRY_DSN      Sentry server address
-  -M MAX_MESSAGE_LENGTH, --max-message-length MAX_MESSAGE_LENGTH
+  -M STRING_MAX_LENGTH, --string-max-length STRING_MAX_LENGTH
                         The maximum characters of a string that should be sent
                         to Sentry (defaults to 4094)
   -q, --quiet           suppress all command output

--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -10,11 +10,9 @@ from time import time
 from .version import VERSION
 
 
-# More info:
-# * https://github.com/getsentry/sentry/blob/b44cdaa27e1ba3f27d217f7f7f45efaa5e742d0f/src/sentry/conf/server.py#L742-L744
-# * https://github.com/getsentry/sentry/blob/5d6b0fef0f4446128730d9c1f5940e7f071a4509/src/sentry/utils/safe.py#L68-L76
-# the value is 4094 because of `_size += 2` in the code linked above
-DEFAULT_STRING_MAX_LENGTH = 4094
+# 4096 is more than Sentry will accept by default. SENTRY_MAX_EXTRA_VARIABLE_SIZE in the Sentry configuration 
+# also needs to be increased to allow longer strings.
+DEFAULT_STRING_MAX_LENGTH = 4096
 
 
 parser = ArgumentParser(

--- a/tests/test_command_reporter.py
+++ b/tests/test_command_reporter.py
@@ -1,11 +1,11 @@
 import mock
 import sys
-from cron_sentry.runner import CommandReporter, DEFAULT_MAX_MESSAGE_LENGTH, run, parser
+from cron_sentry.runner import CommandReporter, DEFAULT_STRING_MAX_LENGTH, run, parser
 
 
 @mock.patch('cron_sentry.runner.Client')
 def test_command_reporter_accepts_parameters(ClientMock):
-    reporter = CommandReporter(['date', '--invalid-option'], 'http://testdsn', DEFAULT_MAX_MESSAGE_LENGTH)
+    reporter = CommandReporter(['date', '--invalid-option'], 'http://testdsn', DEFAULT_STRING_MAX_LENGTH)
 
     reporter.run()
 
@@ -15,7 +15,7 @@ def test_command_reporter_accepts_parameters(ClientMock):
 
 @mock.patch('cron_sentry.runner.Client')
 def test_command_reporter_works_with_no_params_commands(ClientMock):
-    reporter = CommandReporter(['date'], 'http://testdsn', DEFAULT_MAX_MESSAGE_LENGTH)
+    reporter = CommandReporter(['date'], 'http://testdsn', DEFAULT_STRING_MAX_LENGTH)
 
     reporter.run()
 
@@ -32,7 +32,7 @@ sys.stdout.write("test-out")
 sys.stderr.write("test-err")
 sys.exit(2)
 """]
-    reporter = CommandReporter(command, 'http://testdsn', DEFAULT_MAX_MESSAGE_LENGTH)
+    reporter = CommandReporter(command, 'http://testdsn', DEFAULT_STRING_MAX_LENGTH)
     client = ClientMock()
 
     reporter.run()
@@ -60,12 +60,12 @@ sys.stdout.write("a" * 20000)
 sys.stderr.write("b" * 20000)
 sys.exit(2)
 """]
-    reporter = CommandReporter(command, 'http://testdsn', DEFAULT_MAX_MESSAGE_LENGTH)
+    reporter = CommandReporter(command, 'http://testdsn', DEFAULT_STRING_MAX_LENGTH)
     client = ClientMock()
 
     reporter.run()
-    expected_stdout = '...{0}'.format('a' * (DEFAULT_MAX_MESSAGE_LENGTH - 3))
-    expected_stderr = '...{0}'.format('b' * (DEFAULT_MAX_MESSAGE_LENGTH - 3))
+    expected_stdout = '...{0}'.format('a' * (DEFAULT_STRING_MAX_LENGTH - 3))
+    expected_stderr = '...{0}'.format('b' * (DEFAULT_STRING_MAX_LENGTH - 3))
 
     sys_mock.stdout.write.assert_called_with(expected_stdout)
     sys_mock.stderr.write.assert_called_with(expected_stderr)
@@ -91,7 +91,7 @@ def test_command_line_should_support_command_args_without_double_dashes(CommandR
     CommandReporterMock.assert_called_with(
         cmd=command[2:],
         dsn='http://testdsn',
-        max_message_length=DEFAULT_MAX_MESSAGE_LENGTH,
+        string_max_length=DEFAULT_STRING_MAX_LENGTH,
         quiet=False
     )
 
@@ -106,7 +106,7 @@ def test_command_line_should_support_command_with_double_dashes(CommandReporterM
     CommandReporterMock.assert_called_with(
         cmd=command[3:],
         dsn='http://testdsn',
-        max_message_length=DEFAULT_MAX_MESSAGE_LENGTH,
+        string_max_length=DEFAULT_STRING_MAX_LENGTH,
         quiet=False
     )
 


### PR DESCRIPTION

![skarmavbild 2015-10-07 kl 12 56 09](https://cloud.githubusercontent.com/assets/13788469/10366010/bc03bdb6-6dc7-11e5-913f-6fbf3c9fe457.png)
Argument string_max_length=-1 make Raven truncate one char at the end of all strings. Raven takes a positive integer as argument for string_max_length and if it need to be unlimited the change needs to be made in the Ravens API.  It seems to be the same bug as #10