### PR TITLE
Use Raven's synchronous blocking transport (HTTPTransport)

### DIFF
--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -2,6 +2,7 @@ import sys
 from getpass import getuser
 from os import getenv, path, SEEK_END
 from raven import Client
+from raven.transport.http import HTTPTransport
 from subprocess import call
 from tempfile import TemporaryFile
 from argparse import ArgumentParser, REMAINDER
@@ -139,7 +140,7 @@ class CommandReporter(object):
 
         message = "Command \"%s\" failed" % (self.command,)
 
-        client = Client(dsn=self.dsn, string_max_length=self.string_max_length)
+        client = Client(transport=HTTPTransport, dsn=self.dsn, string_max_length=self.string_max_length)
 
         client.captureMessage(
             message,


### PR DESCRIPTION
Raven's default transport is `ThreadedHTTPTransport`: an "*async worker for processing messages*". This is probably overkill for our usage as making the Raven Client process messages asynchronously in a worker seems to be unnecessary given **cron-sentry**'s role as a simple CLI wrapper for Sentry.

There's a more frustrating issue though with the `ThreadedHTTPTransport`: it has an aggressive initial timeout of 0.1 seconds after which it will print a warning to `stdout` with the total timeout it will wait and key sequences to abort the sending process. In a non-interactive context this is unhelpful, but worse, it will result in output even when running **cron-sentry** with the `--quiet` parameter to silence output.

If the Sentry server is at all slow to respond this will result in Cron email alerts being sent even when running with `--quiet` with just the "*Sentry is attempting to send 1 pending error messages...*" as content.

We could potentially try and fix this upstream in various ways, but the synchronous worker will fix this anyway, and is probably a better fit.

Assuming there's no interesting in making the Raven client transport to be used configurable at runtime, this pull request should be sufficient!