### PR TITLE
Write to stderr if sentry gives errors

### DIFF
--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -138,6 +138,10 @@ class CommandReporter(object):
 
     def run(self):
         start = time()
+        
+        # Print something on stdout if raven gives an error
+        import logging
+        logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s")
 
         with TemporaryFile() as stdout:
             with TemporaryFile() as stderr:


### PR DESCRIPTION
Without this only:

    No handlers could be found for logger "sentry.errors"

is printed.

Originally proposed here:

https://github.com/dvarrazzo/raven-cron/commit/4ed0584821bb4389b419c9e5d79e42772ecaec59