### PR TITLE
Document PYTHONIOENCODING for UTF-8 IO handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,17 @@ Example
     SENTRY_DSN=https://<your_key>:<your_secret>@app.getsentry.com/<your_project_id>
     0 4 * * * cron-sentry my-process --arg arg2
 
+Notes
+-----
+
+- If your command outputs Unicode, you may need to signal to python that stdin/stdout/stderr are UTF-8 encoded:
+
+::
+
+    PYTHONIOENCODING=utf-8
+    SENTRY_DSN=https://<your_key>:<your_secret>@app.getsentry.com/<your_project_id>
+    0 4 * * * cron-sentry my-process --arg arg2
+
 License
 -------
 


### PR DESCRIPTION
On Ubuntu 14.04 / python 2.7.6, we encountered the error below when a command emitted UTF-8. The solution was to signal to python that stdin/stdout/stderr were UTF-8 encoded by crontab environment variable:

```
PYTHONIOENCODING=utf8
```

This patch adds this as a note to the README.

```
Traceback (most recent call last):
  File "/usr/local/bin/cron-sentry", line 9, in <module>
    load_entry_point('cron-sentry==0.7.0', 'console_scripts', 'cron-sentry')()
  File "/usr/local/lib/python2.7/dist-packages/cron_sentry/runner.py", line 122, in run
    sys.exit(runner.run())
  File "/usr/local/lib/python2.7/dist-packages/cron_sentry/runner.py", line 159, in run
    sys.stdout.write(last_lines_stdout)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 175-268: ordinal not in range(128)
```
