### PR TITLE
Fix crash with newer versions of raven

### DIFF
--- a/cron_sentry/runner.py
+++ b/cron_sentry/runner.py
@@ -9,7 +9,9 @@ from argparse import ArgumentParser, REMAINDER
 from sys import argv
 from time import time
 from .version import VERSION
+import logging
 
+logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s")
 
 # 4096 is more than Sentry will accept by default. SENTRY_MAX_EXTRA_VARIABLE_SIZE in the Sentry configuration
 # also needs to be increased to allow longer strings.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
* Fix logging issue with newer versions of Raven
* config cron-sentry to be a universal py2/py3 bdist wheel